### PR TITLE
Fix max class num counting bug

### DIFF
--- a/static/src/components/Home.tsx
+++ b/static/src/components/Home.tsx
@@ -69,7 +69,7 @@ class Home extends React.Component<IHomeProps, any> {
         ? this.props.issueTable.works
         : filterWorksByProjectNames(this.props.issueTable.works, [this.props.global.selectedProjectName]);
 
-    const maxClassNumWork = _.maxBy(works, w => (w.Label ? w.Label.ParentNames.length : 0));
+    const maxClassNumWork = _.maxBy(works, w => (w.Label ? w.Label.ParentNames.length + 1 : 0));
     const maxClassNum =
       maxClassNumWork && maxClassNumWork.Label
         ? maxClassNumWork.Label.ParentNames.length + 1 // 1 is work own label


### PR DESCRIPTION
_.maxBy return first one of elements that have same value.
If any work.Label does not have label parent, _.maxBy return element of works[0] because value of all elements are 0.